### PR TITLE
Use fixed-string for package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ DESCRIPTION = 'A simple wrapper around the Google Places API.'
 
 setup(
     name = 'python-google-places',
-    version = __version__,
+    version = "1.4.3",
     url = 'http://github.com/slimkrazy/python-google-places',
     author = __author__,
     author_email = __email__,


### PR DESCRIPTION
Poetry can not retrieve version because it is parsing setup.py with AST
parsing and thus consider there is no version of the package.
Read more: https://github.com/sdispater/poetry/issues/673