### PR TITLE
Replace distutils with setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 from googleplaces import __author__, __email__, __version__
 


### PR DESCRIPTION
Poetry can not retrieve version because the `setup.py` file uses `distutils` which does not provide the `egg_info`command for depency resolution. When the command is not available, poetry tries to retrieve version and dependencies as strings in `setup.py` with AST parsing which cannot interpret `__version__` variable. Because of that, Poetry thinks there is no available version and refuse to add dependency.
Read more: sdispater/poetry#673

While `distutils` does not provide capacity to generate the `egg_info` command `setuptools` can and it is the now (as of 2019) recommended tool to generate package setup files.

Here is an abstract from python official documentation:
```
Although you can use pure distutils for many projects, it does not support defining dependencies on other projects and is missing several convenience utilities for automatically populating distribution metadata correctly that are provided by setuptools. Being outside the standard library, setuptools also offers a more consistent feature set across different versions of Python, and (unlike distutils), recent versions of setuptools support all of the modern metadata fields described in Core metadata specifications.
```
source: https://packaging.python.org/guides/tool-recommendations/